### PR TITLE
Feature/csc sim instances

### DIFF
--- a/Dockerfile-atdome
+++ b/Dockerfile-atdome
@@ -1,6 +1,7 @@
 FROM lsstts/develop-env:20190705_sal3.10.0_salobj
 
 COPY csc-sim/atdome-setup.sh /home/saluser/atdome-setup.sh
+COPY csc-sim/atdome.py /home/saluser/atdome.py
 COPY config /home/saluser/config
 
 ENTRYPOINT ["/bin/bash", "--"]

--- a/Dockerfile-scriptqueue
+++ b/Dockerfile-scriptqueue
@@ -1,6 +1,7 @@
 FROM lsstts/develop-env:20190705_sal3.10.0_salobj
 
 COPY csc-sim/scriptqueue-setup.sh /home/saluser/scriptqueue-setup.sh
+COPY csc-sim/scriptqueue.py /home/saluser/scriptqueue.py
 COPY config /home/saluser/config
 WORKDIR /home/saluser
 ENTRYPOINT ["/home/saluser/scriptqueue-setup.sh"]

--- a/csc-sim/atdome-setup.sh
+++ b/csc-sim/atdome-setup.sh
@@ -20,7 +20,6 @@ setup ts_config_attcs -t current
 
 setup ts_ATDome -t $USER 
 
-cd /home/saluser/repos/ts_ATDome/bin/
-
-echo "# Starting ATDome Simulator CSC"
-python ./run_atdome.py -s -i 1
+cd /home/saluser/
+echo "# Starting ATDome Simulator CSCs for every salindex with a 'command_sim' source in the config file"
+python -u atdome.py

--- a/csc-sim/atdome.py
+++ b/csc-sim/atdome.py
@@ -1,0 +1,19 @@
+import asyncio
+import json
+from lsst.ts import ATDome
+
+simulator_config_path = '/home/saluser/config/config.json'
+with open(simulator_config_path) as f:
+    simulator_config = json.loads(f.read())
+
+if 'ATDome' in simulator_config.keys():
+    awaitables = []
+    for atdome_config in simulator_config['ATDome']:
+        if atdome_config['source'] == 'command_sim':
+            salindex = atdome_config['index']
+            print('ATDome csc | Launching salindex = {}'.format(salindex))
+            csc = ATDome.ATDomeCsc(index=salindex,
+                                   initial_simulation_mode=True)
+            awaitables.append(csc.done_task)
+
+asyncio.get_event_loop().run_until_complete(asyncio.wait(awaitables))

--- a/csc-sim/scriptqueue-setup.sh
+++ b/csc-sim/scriptqueue-setup.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 source .setup.sh
-run_script_queue.py --standard ~/repos/ts_scriptqueue/tests/data/standard/ --external ~/repos/ts_scriptqueue/tests/data/external 1
+python -u scriptqueue.py

--- a/csc-sim/scriptqueue.py
+++ b/csc-sim/scriptqueue.py
@@ -1,0 +1,23 @@
+import asyncio
+import json
+from lsst.ts import scriptqueue
+
+standardpath = '/home/saluser/repos/ts_scriptqueue/tests/data/standard/'
+externalpath = '/home/saluser/repos/ts_scriptqueue/tests/data/external'
+
+simulator_config_path = '/home/saluser/config/config.json'
+with open(simulator_config_path) as f:
+    simulator_config = json.loads(f.read())
+
+if 'ScriptQueue' in simulator_config.keys():
+    awaitables = []
+    for scriptqueue_config in simulator_config['ScriptQueue']:
+        if scriptqueue_config['source'] == 'command_sim':
+            salindex = scriptqueue_config['index']
+            print('ScriptQueue csc | Launching salindex = {}'.format(salindex))
+            csc = scriptqueue.ScriptQueue(index=salindex,
+                                          standardpath=standardpath,
+                                          externalpath=externalpath)
+            awaitables.append(csc.done_task)
+
+asyncio.get_event_loop().run_until_complete(asyncio.wait(awaitables))


### PR DESCRIPTION
Launch several instances of the cscs (scriptqueue and atdome) for each salindex with `source:"command_sim"` in the `config.json`.

closes #10 