### PR TITLE
Upgrade dev-cycle to c0021.007

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
 #
 # Development cycle to build
 #
-dev_cycle=c0020.006
+dev_cycle=c0021.007

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ pipeline {
     weatherstationImage = ""
     testCSCImage = ""
     jupyterImage = ""
-    dev_cycle = "c0020.006"
+    dev_cycle = "c0021.007"
     user_ci = credentials('lsst-io')
     LTD_USERNAME="${user_ci_USR}"
     LTD_PASSWORD="${user_ci_PSW}"


### PR DESCRIPTION
This PR make some changes to be compliant with the docker image `lsstts/develop-env` version `c0021.007`