### PR TITLE
Update simulators

### DIFF
--- a/Dockerfile-scriptqueue
+++ b/Dockerfile-scriptqueue
@@ -4,5 +4,9 @@ FROM lsstts/develop-env:${dev_cycle}
 COPY csc_sim/scriptqueue-setup.sh /home/saluser/scriptqueue-setup.sh
 COPY csc_sim/scriptqueue.py /home/saluser/scriptqueue.py
 COPY config /home/saluser/config
+
+RUN cp -R /home/saluser/repos/ts_standardscripts/scripts/ /home/saluser/repos/ts_scriptqueue/tests/data/standard/scripts/
+RUN cp -R /home/saluser/repos/ts_externalscripts/scripts/ /home/saluser/repos/ts_scriptqueue/tests/data/external/scripts/
+
 WORKDIR /home/saluser
 ENTRYPOINT ["/home/saluser/scriptqueue-setup.sh"]

--- a/config/config.json
+++ b/config/config.json
@@ -1,17 +1,22 @@
 {
-  "ATDome": [
-    {
-      "source": "command_sim"
-    }
-  ],
-  "ATMCS": [
-    {
-      "source": "command_sim"
-    }
-  ],
   "ScriptQueue": [
     {
       "index": 1,
+      "source": "command_sim"
+    },
+    {
+      "index": 2,
+      "source": "command_sim"
+    },
+  ],
+  "WeatherStation": [{ "index": 1, "source": "command_sim" }],
+  "Test": [
+    {
+      "index": 1,
+      "source": "command_sim"
+    },
+    {
+      "index": 2,
       "source": "command_sim"
     }
   ]


### PR DESCRIPTION
This PR makes a change to the ScriptQueue simulator to include standard and external scripts on build time. Also we added some missing simulators to the `config.json` file.