### PR TITLE
Update Watcher and WeatherStation sims configurations

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ pipeline {
         anyOf {
           changeset "csc_sim/atcs-setup.sh"
           changeset "config/*"
-          changeset "Dockerfile-atcs"
+          changeset "docker/Dockerfile-atcs"
           changeset "Jenkinsfile"
           expression {
             return currentBuild.number == 1
@@ -66,7 +66,7 @@ pipeline {
         anyOf {
           changeset "csc_sim/atcs-setup.sh"
           changeset "config/*"
-          changeset "Dockerfile-atcs"
+          changeset "docker/Dockerfile-atcs"
           changeset "Jenkinsfile"
           expression {
             return currentBuild.number == 1
@@ -95,7 +95,7 @@ pipeline {
         anyOf {
           changeset "csc_sim/mtcs-setup.sh"
           changeset "config/*"
-          changeset "Dockerfile-mtcs"
+          changeset "docker/Dockerfile-mtcs"
           changeset "Jenkinsfile"
           expression {
             return currentBuild.number == 1
@@ -132,7 +132,7 @@ pipeline {
         anyOf {
           changeset "csc_sim/mtcs-setup.sh"
           changeset "config/*"
-          changeset "Dockerfile-mtcs"
+          changeset "docker/Dockerfile-mtcs"
           changeset "Jenkinsfile"
           expression {
             return currentBuild.number == 1
@@ -161,7 +161,7 @@ pipeline {
         anyOf {
           changeset "csc_sim/testcsc-setup.sh"
           changeset "config/*"
-          changeset "Dockerfile-testcsc"
+          changeset "docker/Dockerfile-testcsc"
           changeset "Jenkinsfile"
           expression {
             return currentBuild.number == 1
@@ -198,7 +198,7 @@ pipeline {
         anyOf {
           changeset "csc_sim/testcsc-setup.sh"
           changeset "config/*"
-          changeset "Dockerfile-testcsc"
+          changeset "docker/Dockerfile-testcsc"
           changeset "Jenkinsfile"
           expression {
             return currentBuild.number == 1
@@ -227,7 +227,7 @@ pipeline {
         anyOf {
           changeset "csc_sim/scriptqueue-setup.sh"
           changeset "config/*"
-          changeset "Dockerfile-scriptqueue"
+          changeset "docker/Dockerfile-scriptqueue"
           changeset "Jenkinsfile"
           expression {
             return currentBuild.number == 1
@@ -264,7 +264,7 @@ pipeline {
         anyOf {
           changeset "csc_sim/scriptqueue-setup.sh"
           changeset "config/*"
-          changeset "Dockerfile-scriptqueue"
+          changeset "docker/Dockerfile-scriptqueue"
           changeset "Jenkinsfile"
           expression {
             return currentBuild.number == 1
@@ -293,7 +293,7 @@ pipeline {
         anyOf {
           changeset "csc_sim/watcher-setup.sh"
           changeset "config/*"
-          changeset "Dockerfile-watcher"
+          changeset "docker/Dockerfile-watcher"
           changeset "Jenkinsfile"
           expression {
             return currentBuild.number == 1
@@ -331,7 +331,7 @@ pipeline {
         anyOf {
           changeset "csc_sim/watcher-setup.sh"
           changeset "config/*"
-          changeset "Dockerfile-watcher"
+          changeset "docker/Dockerfile-watcher"
           changeset "Jenkinsfile"
           expression {
             return currentBuild.number == 1
@@ -360,7 +360,7 @@ pipeline {
         anyOf {
           changeset "csc_sim/weatherstation-setup.sh"
           changeset "config/*"
-          changeset "Dockerfile-weatherstation"
+          changeset "docker/Dockerfile-weatherstation"
           changeset "Jenkinsfile"
           expression {
             return currentBuild.number == 1
@@ -398,7 +398,7 @@ pipeline {
         anyOf {
           changeset "csc_sim/weatherstation-setup.sh"
           changeset "config/*"
-          changeset "Dockerfile-weatherstation"
+          changeset "docker/Dockerfile-weatherstation"
           changeset "Jenkinsfile"
           expression {
             return currentBuild.number == 1
@@ -425,7 +425,7 @@ pipeline {
       when {
         anyOf {
           changeset "simulator/jupyter.sh"
-          changeset "Dockerfile-jupyter"
+          changeset "docker/Dockerfile-jupyter"
           changeset "Jenkinsfile"
           expression {
             return currentBuild.number == 1
@@ -461,7 +461,7 @@ pipeline {
       when {
         anyOf {
           changeset "simulator/jupyter.sh"
-          changeset "Dockerfile-jupyter"
+          changeset "docker/Dockerfile-jupyter"
           changeset "Jenkinsfile"
           expression {
             return currentBuild.number == 1

--- a/csc_sim/watcher-setup.sh
+++ b/csc_sim/watcher-setup.sh
@@ -8,7 +8,8 @@ if [[ $LSST_DDS_IP != *"."* ]]; then
 fi
 
 #WRITE CONFIG
-cd /home/saluser/repos/ts_config_ocs/Watcher/v2
+cd /home/saluser/repos/ts_config_ocs/Watcher/
+version=$(ls | sort -V | tail -n 1)
 echo "rules:
 - classname: Enabled
   configs:
@@ -27,7 +28,7 @@ echo "rules:
   - name: ATDome
   - name: WeatherStation
   - name: GenericCamera
-  - name: ScriptQueue:1" > default.yml
+  - name: ScriptQueue:1" > ./$version/default.yml
 
 #RUN WATCHER
 cd /home/saluser/repos/ts_watcher

--- a/csc_sim/weatherstation_configurations.sh
+++ b/csc_sim/weatherstation_configurations.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+echo "# Running develop-env/setup.sh"
+# from ts_sal setup.env
+#export LSST_DDS_QOS=file:///home/saluser/tsrepos/ts_sal/test/python/DDS_DefaultQoS_All.xml
+#export SAL_IDL_DIR=/home/saluser/tsrepos/ts_sal/test/idl-templates/validated/sal
+
+#to use licensed version this may help:
+#export OSPL_HOME=/home/saluser/tsrepos/OpenSpliceDDS/Vortex_v2/Device/VortexOpenSplice/6.10.2/HDE/x86_64.linux
+#export OSPL_TMPL_PATH=$OSPL_HOME/etc/idlpp
+#export OSPL_URI=file:///home/saluser/tsrepos/OpenSpliceDDS/Vortex_v2/Device/VortexOpenSplice/6.10.2/HDE/x86_64.linux/etc/config/ospl.xml
+echo "OSPL_HOME=${OSPL_HOME}"
+
+# ***** SET THIS PATH *****
+export TSREPOS="/home/saluser/repos"
+
+# ***** CHOOSE THE CORRECT ts_sal *****
+# * If using the ts_sal included in the Docker image:
+#   export TS_SAL_DIR=${HOME}/repos/ts_sal
+# * If using your own ts_sal:
+#   export TS_SAL_DIR=${TSREPOS}/ts_sal
+export TS_SAL_DIR=${HOME}/repos/ts_sal
+
+export LSST_SDK_INSTALL=${TS_SAL_DIR}
+
+# Put the correct ts_sal's lsstsal/bin and lsstsal/scripts directories on PATH,
+# to override the default, which is the built-in ts_sal.
+export PATH=${TS_SAL_DIR}/lsstsal/bin:${TS_SAL_DIR}/lsstsal/scripts:${PATH}
+
+# Eliminate duplicates from bash history
+export HISTCONTROL="ignoreboth"
+
+# Load the LSST stack before configuring the SAL environment
+# because SAL's setup.env must find the correct python.
+echo "# Load the LSST Stack"
+. /opt/lsst/software/stack/loadLSST.bash
+
+echo "# Configure ts_sal in ${TS_SAL_DIR}"
+# source /home/saluser/tsrepos/docker/develop-env/setup.env
+source ${TS_SAL_DIR}/setup.env
+
+eups_declare() {
+    eups declare -r "${TSREPOS}/$1" "$1" git -t current
+}
+
+declare_and_setup() {
+    eups_declare "$1"
+    setup -k "$1"
+}
+
+# ***** SETUP YOUR PACKAGES *****
+# Declare and setup packages from your disk;
+# omit any packages you want to use from the Docker image.
+# Be sure to declare packages *before* you setup packages that depend on them.
+echo "# Declare and setup my packages; please ignore \"Warning: path...\" messages"
+setup sconsUtils
+setup -k verify
+eups_declare ts_weatherstation
+declare_and_setup ts_weatherstation
+
+/bin/bash

--- a/docker/Dockerfile-watcher
+++ b/docker/Dockerfile-watcher
@@ -1,6 +1,4 @@
 ARG dev_cycle=develop
-ARG WATCHER_VERSION=v1.8.0
-
 FROM lsstts/develop-env:${dev_cycle}
 
 COPY csc_sim/watcher-setup.sh /home/saluser/watcher-setup.sh
@@ -13,6 +11,6 @@ RUN source /opt/lsst/software/stack/loadLSST.bash \
 
 RUN git clone https://github.com/lsst-ts/ts_watcher.git  /home/saluser/repos/ts_watcher
 
-RUN cd /home/saluser/repos/ts_watcher && git checkout ${WATCHER_VERSION}
+RUN cd /home/saluser/repos/ts_watcher
 ENTRYPOINT ["/bin/bash", "--"]
 CMD ["/home/saluser/watcher-setup.sh"]

--- a/docker/Dockerfile-weatherstation
+++ b/docker/Dockerfile-weatherstation
@@ -2,7 +2,7 @@ ARG dev_cycle=develop
 ARG WEATHERSTATION_VERSION=v1.1.1
 FROM lsstts/develop-env:${dev_cycle}
 
-COPY environment_setup.sh /home/saluser/setup.sh
+COPY csc_sim/weatherstation_configurations.sh /home/saluser/setup.sh
 COPY csc_sim/weatherstation-setup.sh /home/saluser/weatherstation-setup.sh
 COPY csc_sim/weatherstation.py /home/saluser/weatherstation.py
 COPY config /home/saluser/config


### PR DESCRIPTION
This PR makes some small changes to update the Watcher sim configurations. This simulator stopped working after the upgrade of `lsstts/develop-env:c0028`, this changes extends the configurations to comply with this update.
This PR also fixes an issue with the weather-station sim and update the `Jenkinsfile` to consider the new directory structure for storing docker files.