### PR TITLE
Hotfix for Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -497,8 +497,10 @@ pipeline {
         }
       }
       when {
-        branch "main"
-        branch "develop"
+        anyOf {
+          branch "main"
+          branch "develop"
+        }
       }
       steps {
         script {


### PR DESCRIPTION
This PR makes a minor change to fix documentation deployment as the `anyOf` block is required in this case.
For further reference check: https://www.jenkins.io/doc/book/pipeline/syntax/

> The when directive allows the Pipeline to determine whether the stage should be executed depending on the given condition. The when directive must contain at least one condition. If the when directive contains more than one condition, all the child conditions must return true for the stage to execute.